### PR TITLE
feat: update error response on getExchangeRate details

### DIFF
--- a/api/bank.go
+++ b/api/bank.go
@@ -19,6 +19,12 @@ const (
 func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResolveRequest) (model.AccountDetailResponse, error) {
 	endpoint := fmt.Sprintf("%s%s%s", c.baseURL, bankEndpoint, "/resolve-account")
 
+	fL := c.logger.With().Str("func", "ResolveBankAccount").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface("request", request).
+		Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
+
 	response := struct {
 		Data model.AccountDetailResponse `json:"data"`
 	}{}
@@ -31,11 +37,19 @@ func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResol
 		Post(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return model.AccountDetailResponse{}, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.AccountDetailResponse{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.AccountDetailResponse{}, model.ErrNetworkError
+		}
+		return model.AccountDetailResponse{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil
@@ -44,6 +58,11 @@ func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResol
 // GetBanks makes an API request using Call to get list of banks
 func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 	endpoint := fmt.Sprintf("%s%s", c.baseURL, bankEndpoint)
+
+	fL := c.logger.With().Str("func", "GetBanks").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
 
 	response := struct {
 		Data []model.BankCodeResponse `json:"data"`
@@ -56,11 +75,19 @@ func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 		Get(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return response.Data, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return response.Data, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return []model.BankCodeResponse{}, model.ErrNetworkError
+		}
+		return []model.BankCodeResponse{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil
@@ -69,6 +96,12 @@ func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 // GenerateBankAccount makes an API request to generate bank account
 func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccountRequest) (model.BankAccountResponse, error) {
 	endpoint := fmt.Sprintf("%s%s", c.baseURL, bankAccountEndpoint)
+
+	fL := c.logger.With().Str("func", "GenerateBankAccount").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface("request", request).
+		Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	response := struct {
@@ -88,7 +121,14 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.BankAccountResponse{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.BankAccountResponse{}, model.ErrNetworkError
+		}
+		return model.BankAccountResponse{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil
@@ -97,6 +137,13 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 // GetBankAccount makes an API request to get bank account
 func (c *Call) GetBankAccount(ctx context.Context, customerID uuid.UUID) (model.BankAccountResponse, error) {
 	endpoint := fmt.Sprintf("%s%s/%s", c.baseURL, bankAccountEndpoint, customerID)
+
+	fL := c.logger.With().Str("func", "GetBankAccount").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface("request", customerID.String()).
+		Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
+
 	response := struct {
 		Data model.BankAccountResponse `json:"data"`
 	}{}
@@ -107,11 +154,19 @@ func (c *Call) GetBankAccount(ctx context.Context, customerID uuid.UUID) (model.
 		Get(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return model.BankAccountResponse{}, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.BankAccountResponse{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.BankAccountResponse{}, model.ErrNetworkError
+		}
+		return model.BankAccountResponse{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil

--- a/api/customer.go
+++ b/api/customer.go
@@ -40,8 +40,14 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.Customer{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Customer{}, model.ErrNetworkError
+		}
+		return model.Customer{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -73,8 +79,14 @@ func (c *Call) UpdateCustomer(ctx context.Context, request model.UpdateCustomerR
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.Customer{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Customer{}, model.ErrNetworkError
+		}
+		return model.Customer{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -105,8 +117,14 @@ func (c *Call) GetAllCustomers(ctx context.Context) ([]model.Customer, error) {
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return []model.Customer{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return []model.Customer{}, model.ErrNetworkError
+		}
+		return []model.Customer{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -137,8 +155,14 @@ func (c *Call) GetCustomerByID(ctx context.Context, request model.GetCustomerByI
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.CustomerInfo{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.CustomerInfo{}, model.ErrNetworkError
+		}
+		return model.CustomerInfo{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -170,8 +194,14 @@ func (c Call) GetCustomerBalance(ctx context.Context, request model.GetCustomerB
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.CustomerBalanceResponse{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.CustomerBalanceResponse{}, model.ErrNetworkError
+		}
+		return model.CustomerBalanceResponse{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -202,8 +232,14 @@ func (c Call) GetCustomerBalances(ctx context.Context, customerID uuid.UUID) (mo
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.CustomerBalancesResponse{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.CustomerBalancesResponse{}, model.ErrNetworkError
+		}
+		return model.CustomerBalancesResponse{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -233,8 +269,14 @@ func (c Call) DeleteCustomer(ctx context.Context, customerID uuid.UUID) error {
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.ErrNetworkError
+		}
+		return model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response).Msg("response")

--- a/api/deposit.go
+++ b/api/deposit.go
@@ -47,7 +47,13 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 
 	if res.StatusCode() != http.StatusOK {
 		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.Deposit{}, model.ErrNetworkError
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Deposit{}, model.ErrNetworkError
+		}
+		return model.Deposit{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -78,8 +84,14 @@ func (c *Call) GetAllDeposits(ctx context.Context) (model.DepositBatchResponse, 
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.DepositBatchResponse{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.DepositBatchResponse{}, model.ErrNetworkError
+		}
+		return model.DepositBatchResponse{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -89,6 +101,11 @@ func (c *Call) GetAllDeposits(ctx context.Context) (model.DepositBatchResponse, 
 // GetDepositID makes an API request using Call to get deposit by id
 func (c *Call) GetDepositID(ctx context.Context, id uuid.UUID) (model.Deposit, error) {
 	endpoint := fmt.Sprintf("%s%s/%s", c.baseURL, depositAPIVersion, id)
+
+	fL := c.logger.With().Str("func", "GetDepositID").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
 
 	response := struct {
 		Data model.Deposit `json:"data"`
@@ -100,11 +117,19 @@ func (c *Call) GetDepositID(ctx context.Context, id uuid.UUID) (model.Deposit, e
 		Get(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return model.Deposit{}, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.Deposit{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Deposit{}, model.ErrNetworkError
+		}
+		return model.Deposit{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil
@@ -113,6 +138,12 @@ func (c *Call) GetDepositID(ctx context.Context, id uuid.UUID) (model.Deposit, e
 // InternalFundsTransfer makes an api
 func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTransferRequest) (model.Deposit, error) {
 	endpoint := fmt.Sprintf("%s%s", c.baseURL, fundTransferAPIVersion)
+
+	fL := c.logger.With().Str("func", "InternalFundsTransfer").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface("request", request).
+		Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	response := struct {
@@ -128,11 +159,19 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 		Post(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return model.Deposit{}, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.Deposit{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Deposit{}, model.ErrNetworkError
+		}
+		return model.Deposit{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil
@@ -141,6 +180,12 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 // IntraTransfer makes an API request to transfer funds between two customers
 func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferRequest) (model.IntraTransferResponse, error) {
 	endpoint := fmt.Sprintf("%s%s", c.baseURL, intraTransferAPIVersion)
+
+	fL := c.logger.With().Str("func", "IntraTransfer").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface("request", request).
+		Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	response := struct {
@@ -156,11 +201,19 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 		Post(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return model.IntraTransferResponse{}, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.IntraTransferResponse{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.IntraTransferResponse{}, model.ErrNetworkError
+		}
+		return model.IntraTransferResponse{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -41,7 +41,13 @@ func (c *Call) InitiateTransfer(ctx context.Context, request model.InitiateTrans
 
 	if res.StatusCode() != http.StatusOK {
 		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.Transfer{}, model.ErrNetworkError
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Transfer{}, model.ErrNetworkError
+		}
+		return model.Transfer{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -77,7 +83,13 @@ func (c *Call) GetExchangeRates(ctx context.Context, request model.GetExchangeRa
 
 	if res.StatusCode() != http.StatusOK {
 		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.ExchangeRateDetails{}, model.ParseError(err)
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.ExchangeRateDetails{}, model.ErrNetworkError
+		}
+		return model.ExchangeRateDetails{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -77,7 +77,7 @@ func (c *Call) GetExchangeRates(ctx context.Context, request model.GetExchangeRa
 
 	if res.StatusCode() != http.StatusOK {
 		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.ExchangeRateDetails{}, model.ErrServiceNotAvailable
+		return model.ExchangeRateDetails{}, model.ParseError(err)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -77,7 +77,7 @@ func (c *Call) GetExchangeRates(ctx context.Context, request model.GetExchangeRa
 
 	if res.StatusCode() != http.StatusOK {
 		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.ExchangeRateDetails{}, model.ErrNetworkError
+		return model.ExchangeRateDetails{}, model.ErrUnsupportedCurrency
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -77,7 +77,7 @@ func (c *Call) GetExchangeRates(ctx context.Context, request model.GetExchangeRa
 
 	if res.StatusCode() != http.StatusOK {
 		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.ExchangeRateDetails{}, model.ErrUnsupportedCurrency
+		return model.ExchangeRateDetails{}, model.ErrServiceNotAvailable
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -37,8 +37,14 @@ func (c Call) GetWallet(ctx context.Context, request model.WalletRequest) (model
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.Wallet{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Wallet{}, model.ErrNetworkError
+		}
+		return model.Wallet{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -69,8 +75,14 @@ func (c Call) GetWallets(ctx context.Context, customerID string) ([]*model.Walle
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return nil, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return nil, model.ErrNetworkError
+		}
+		return nil, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -100,8 +112,14 @@ func (c Call) GetSupportedAssets(ctx context.Context) ([]*model.SupportedAsset, 
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return nil, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return nil, model.ErrNetworkError
+		}
+		return nil, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")

--- a/api/withdrawal.go
+++ b/api/withdrawal.go
@@ -40,7 +40,13 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 
 	if res.StatusCode() != http.StatusOK {
 		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.Withdrawal{}, model.ErrNetworkError
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Withdrawal{}, model.ErrNetworkError
+		}
+		return model.Withdrawal{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -51,6 +57,12 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalRequest) (model.Withdrawal, error) {
 	endpoint := fmt.Sprintf("%s%s%s", c.baseURL, withdrawalAPIVersion, "/fiat")
 
+	fL := c.logger.With().Str("func", "FiatWithdrawal").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface("request", request).
+		Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
+
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	response := struct {
 		Data model.Withdrawal `json:"data"`
@@ -65,11 +77,19 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 		Post(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return model.Withdrawal{}, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.Withdrawal{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Withdrawal{}, model.ErrNetworkError
+		}
+		return model.Withdrawal{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil
@@ -79,6 +99,12 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequest) (model.Withdrawal, error) {
 	endpoint := fmt.Sprintf("%s%s%s", c.baseURL, withdrawalAPIVersion, "/crypto")
 
+	fL := c.logger.With().Str("func", "CryptoWithdrawal").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface("request", request).
+		Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
+
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	response := struct {
 		Data model.Withdrawal `json:"data"`
@@ -93,11 +119,19 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 		Post(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return model.Withdrawal{}, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.Withdrawal{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.Withdrawal{}, model.ErrNetworkError
+		}
+		return model.Withdrawal{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil
@@ -106,6 +140,12 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 // FeeWithdrawal makes an API request to withdrawal for withdrawal fees
 func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalRequest) (model.FeeWithdrawal, error) {
 	endpoint := fmt.Sprintf("%s%s%s", c.baseURL, withdrawalAPIVersion, "/fee")
+
+	fL := c.logger.With().Str("func", "FeeWithdrawal").Str("endpoint", endpoint).Logger()
+	fL.Info().Msg("starting...")
+	fL.Info().Interface("request", request).
+		Interface(model.LogStrRequest, "empty").Msg("request")
+	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	response := struct {
@@ -121,11 +161,19 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 		Post(endpoint)
 
 	if err != nil {
+		fL.Err(err).Msg("error occurred")
 		return model.FeeWithdrawal{}, err
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		return model.FeeWithdrawal{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.FeeWithdrawal{}, model.ErrNetworkError
+		}
+		return model.FeeWithdrawal{}, model.ParseError(errRes.Error.Details)
 	}
 
 	return response.Data, nil

--- a/api/yield.go
+++ b/api/yield.go
@@ -34,8 +34,14 @@ func (c *Call) GetBusinessPortfolios(ctx context.Context) ([]model.Portfolio, er
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return []model.Portfolio{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return []model.Portfolio{}, model.ErrNetworkError
+		}
+		return []model.Portfolio{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -70,8 +76,14 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.YieldOfferingProfile{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.YieldOfferingProfile{}, model.ErrNetworkError
+		}
+		return model.YieldOfferingProfile{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -103,8 +115,14 @@ func (c *Call) UpdateYieldOfferingProfile(ctx context.Context, request model.Upd
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.UpdatedYieldOfferingProfile{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.UpdatedYieldOfferingProfile{}, model.ErrNetworkError
+		}
+		return model.UpdatedYieldOfferingProfile{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -135,8 +153,14 @@ func (c *Call) GetAllYieldProfiles(ctx context.Context) ([]model.YieldOfferingPr
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return []model.YieldOfferingProfile{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return []model.YieldOfferingProfile{}, model.ErrNetworkError
+		}
+		return []model.YieldOfferingProfile{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")
@@ -167,8 +191,14 @@ func (c *Call) GetYieldProfileByID(ctx context.Context, request model.GetYieldPr
 	}
 
 	if res.StatusCode() != http.StatusOK {
-		fL.Info().Str(model.LogErrorCode, fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
-		return model.YieldOfferingProfile{}, model.ErrNetworkError
+		fL.Info().Str("error_code", fmt.Sprintf("%d", res.StatusCode())).Msg(string(res.Body()))
+		var errRes model.ErrorResponse
+		errRes, err = model.GetErrorDetails(string(res.Body()))
+		if err != nil {
+			fL.Err(err).Msg("error occurred")
+			return model.YieldOfferingProfile{}, model.ErrNetworkError
+		}
+		return model.YieldOfferingProfile{}, model.ParseError(errRes.Error.Details)
 	}
 
 	fL.Info().Interface(model.LogStrResponse, response.Data).Msg("response")

--- a/main.go
+++ b/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/ovalfi/go-sdk/model/example"
 	"github.com/rs/zerolog"
 
 	"github.com/ovalfi/go-sdk/api"
@@ -39,52 +42,52 @@ func main() {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	fmt.Printf("new customer: %+v\n", retrievedCustomer)
+	fmt.Printf("new customer: %+v\n", retrievedCustomer)*/
 
-	retrievedCustomers, err := apiCalls.GetAllCustomers(ctx)
+	/*retrievedCustomers, err := apiCalls.GetAllCustomers(ctx)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	fmt.Printf("new customer: %+v\n", retrievedCustomers)
+	fmt.Printf("new customer: %+v\n", retrievedCustomers)*/
 
-	//portfolios, err := apiCalls.GetBusinessPortfolios(ctx)
-	//if err != nil {
-	//	fmt.Printf("Error: %v\n", err)
-	//	return
-	//}
-	//fmt.Printf("portfolios: %+v\n", portfolios)
-	//"portfolio_id": "c7115f87-11aa-4d69-bcb4-c12dd7f5bf2f"
+	/*portfolios, err := apiCalls.GetBusinessPortfolios(ctx)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("portfolios: %+v\n", portfolios)
+	"portfolio_id": "c7115f87-11aa-4d69-bcb4-c12dd7f5bf2f"*/
 
-	//newYieldOffering, err := apiCalls.CreateYieldOfferingProfile(ctx, example.NewCreateYieldOfferingProfilesRequest)
-	//if err != nil {
-	//	fmt.Printf("Error: %v\n", err)
-	//	return
-	//}
-	//fmt.Printf("new yield offering: %+v\n", newYieldOffering)
-	//"yield_offering_id": "ef8891af-e887-4e2c-ac79-7a9682d1ad77"
+	/*newYieldOffering, err := apiCalls.CreateYieldOfferingProfile(ctx, example.NewCreateYieldOfferingProfilesRequest)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("new yield offering: %+v\n", newYieldOffering)
+	"yield_offering_id": "ef8891af-e887-4e2c-ac79-7a9682d1ad77"*/
 
-	//updatedYieldOffering, err := apiCalls.UpdateYieldOfferingProfile(ctx, example.NewUpdateYieldOfferingProfilesRequest)
-	//if err != nil {
-	//	fmt.Printf("Error: %v\n", err)
-	//	return
-	//}
-	//fmt.Printf("updated yield offering: %+v\n", updatedYieldOffering)
-	//"yield_offering_id": "ef8891af-e887-4e2c-ac79-7a9682d1ad77"
+	/*updatedYieldOffering, err := apiCalls.UpdateYieldOfferingProfile(ctx, example.NewUpdateYieldOfferingProfilesRequest)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("updated yield offering: %+v\n", updatedYieldOffering)
+	"yield_offering_id": "ef8891af-e887-4e2c-ac79-7a9682d1ad77"*/
 
-	//yieldProfiles, err := apiCalls.GetAllYieldProfiles(ctx)
-	//if err != nil {
-	//	fmt.Printf("Error: %v\n", err)
-	//	return
-	//}
-	//fmt.Printf("yield profiles: %+v\n", yieldProfiles)
+	/*yieldProfiles, err := apiCalls.GetAllYieldProfiles(ctx)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("yield profiles: %+v\n", yieldProfiles)*/
 
-	//retrievedYieldProfile, err := apiCalls.GetYieldProfileByID(ctx, example.NewGetYieldProfileByIDRequest)
-	//if err != nil {
-	//	fmt.Printf("Error: %v\n", err)
-	//	return
-	//}
-	//fmt.Printf("retrieved yield profile: %+v\n", retrievedYieldProfile)
+	retrievedYieldProfile, err := apiCalls.GetYieldProfileByID(context.Background(), example.NewGetYieldProfileByIDRequest)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("retrieved yield profile: %+v\n", retrievedYieldProfile)
 
 	//newDeposit, err := apiCalls.InitiateDeposit(ctx, example.NewDepositRequest)
 	//if err != nil {
@@ -130,7 +133,7 @@ func main() {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	fmt.Printf("all wallet info: %+v\n", *allWallet[0])*/
+	fmt.Printf("all wallet info: %+v\n", *allWallet[0])
 	/*assets, err := apiCalls.GetSupportedAssets(ctx)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
@@ -205,7 +208,22 @@ func main() {
 	/*details, err := apiCalls.GetExchangeRates(context.Background(), model.GetExchangeRateRequest{
 		Amount:              3000,
 		SourceCurrency:      "USD",
-		DestinationCurrency: "NGN",
+		DestinationCurrency: "TRON",
+	})
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Println("details", details)*/
+
+	/*details, err := apiCalls.InitiateTransfer(context.Background(), model.InitiateTransferRequest{
+		CustomerID:  "9f40fb69-64e3-4d23-853a-0243af155427",
+		Amount:      3000,
+		Currency:    "USD",
+		Destination: model.TransferDestination{},
+		Note:        "",
+		Reason:      "",
+		Reference:   "",
 	})
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
@@ -230,6 +248,7 @@ func main() {
 		return
 	}
 	fmt.Println("account", account)*/
+
 	/*withdrawal, err := apiCalls.FiatWithdrawal(ctx, model.WithdrawalRequest{
 		CustomerID:      uuid.MustParse("9f40fb69-64e3-4d23-853a-0243af155427"),
 		Reference:       "polkj",

--- a/model/errors.go
+++ b/model/errors.go
@@ -1,8 +1,11 @@
 package model
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrNetworkError when something goes wrong with the API call
-	ErrNetworkError = errors.New("network error")
+	ErrNetworkError        = errors.New("network error")
+	ErrUnsupportedCurrency = errors.New("currency is not a supported currency")
 )

--- a/model/errors.go
+++ b/model/errors.go
@@ -2,10 +2,18 @@ package model
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 )
 
 var (
 	// ErrNetworkError when something goes wrong with the API call
-	ErrNetworkError        = errors.New("network error")
-	ErrServiceNotAvailable = errors.New("this service is currently unavailable. Please try again later")
+	ErrNetworkError = errors.New("network error")
 )
+
+// ParseError parses error message to one that we can see publicly
+func ParseError(errMsg error) error {
+	// the error looks like: "user with this email does not exist"
+	response := fmt.Errorf("%q%q", strings.ToUpper(errMsg.Error()[0:1]), errMsg.Error()[1:])
+	return response
+}

--- a/model/errors.go
+++ b/model/errors.go
@@ -7,5 +7,5 @@ import (
 var (
 	// ErrNetworkError when something goes wrong with the API call
 	ErrNetworkError        = errors.New("network error")
-	ErrUnsupportedCurrency = errors.New("currency is not a supported currency")
+	ErrServiceNotAvailable = errors.New("this service is currently unavailable. Please try again later")
 )

--- a/model/model.go
+++ b/model/model.go
@@ -13,12 +13,13 @@ const (
 	BaseURL = "https://sandbox-api.ovalfi-app.com/api/"
 
 	// PublicKey sample sandbox environment signature
-	PublicKey = "XC-WlyMxbC7MdS-mlzZ0G1tBBUXu" // "_Wjz3hGNJ8h1FwjJhNHnHXJJmT9Dkg=="
+	PublicKey = "YbAO71rFXyWp0WJq-_yH7AFV6cZ7P71V53Y=" //"_Wjz3hGNJ8h1FwjJhNHnHXJJmT9Dkg=="  // "XC-WlyMxbC7MdS-mlzZ0G1tBBUXu"
 
 	// BearerToken sample sandbox environment bearer token
-	BearerToken = "eyJidXNpbmVzc0lEIjoiYjIxYTQ0YjAtYzI1Yi00NzRiLWE5ODYtOGFmNjI3MTA5YzE5IiwidXNlcklEIjoiOWVhYmJkYzQtOTg3Ny00ZDI4LTgyNTQtMTg4NjBjYWNjMDQ1Iiwia2V5IjoicGVudGEifQ=="
+	BearerToken = "eyJidXNpbmVzc0lEIjoiYjIxYTQ0YjAtYzI1Yi00NzRiLWE5ODYtOGFmNjI3MTA5YzE5IiwidXNlcklEIjoiOWVhYmJkYzQtOTg3Ny00ZDI4LTgyNTQtMTg4NjBjYWNjMDQ1Iiwia2V5IjoiUGVudGFtb25leSJ9"
 
 	//BearerToken = "eyJidXNpbmVzc0lEIjoiOTIzYjJkZjUtNGE4OS00Y2ViLWIxNDgtYzJlNWFjNTJkMDRlIiwidXNlcklEIjoiMjQ4YmFhNDMtYzQ0Yi00ZjYwLWI2MWQtY2VlZjYwOThjNzg1Iiwia2V5IjoidXBwcHBwIn0="
+	//BearerToken = "eyJidXNpbmVzc0lEIjoiYjIxYTQ0YjAtYzI1Yi00NzRiLWE5ODYtOGFmNjI3MTA5YzE5IiwidXNlcklEIjoiOWVhYmJkYzQtOTg3Ny00ZDI4LTgyNTQtMTg4NjBjYWNjMDQ1Iiwia2V5IjoicGVudGEifQ=="
 
 	// LogStrRequest log string key
 	LogStrRequest = "request"


### PR DESCRIPTION
- We want to return a more descriptive error response on a call to sdk endpoints.

Sample error response from 
```
  apiCalls.FiatWithdrawal(context.Background(), model.WithdrawalRequest{
		CustomerID:      uuid.MustParse("9f40fb69-64e3-4d23-853a-0243af155427"),
		Reference:       "polkj",
		Amount:          10,
		YieldOfferingID: uuid.MustParse("42ee80d8-2a95-419c-aad1-5643d306948e"),
		PayoutCurrency:  "NGN",
		BankDetail: &model.BankDetail{
			BankCode:      "057",
			AccountNumber: "2209276822",
		},
	})
```
will return possible error responses like below
- `this service is currently unavailable. Please try again later`.
- `Customer does not exist.`

ref https://ovalfi.atlassian.net/browse/PAP-199