### PR TITLE
feat: cater for request-id set on the header to calls to externalapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ To run this project, you will need to add the following environment variables to
 
 `BEARER_TOKEN`
 
+````
+Note: You can also set the `api_RequestIDContextKey` as the key for the request-id for the current context passed.
+This is expected to be a valid uuid.UUID string.
+
+This will be contained in our response payload, on the `X-REQUEST-ID` header.
+````
+
 
 <!-- Getting Started -->
 ## 	:toolbox: Getting Started

--- a/README.md
+++ b/README.md
@@ -90,11 +90,17 @@ To run this project, you will need to add the following environment variables to
 
 `BEARER_TOKEN`
 
+**Also, we have a system in place to track API requests via the SDK. For every context you pass in the communication with our APIs, we require that you add a `requestID` of type uuid.UUID string to the context.
+This must be passed in the context like below:**
 ````
-Note: You can also set the `api_RequestIDContextKey` as the key for the request-id for the current context passed.
-This is expected to be a valid uuid.UUID string.
+{
 
-This will be contained in our response payload, on the `X-REQUEST-ID` header.
+    ctx := context.WithValue(context.Background(), "api_RequestIDContextKey", requestID),
+
+}
+
+Note:In our payload response to your API calls, we now have an header field like this: `X-Request-Id: 71fb13a7-595f-49b8-bdd3-2eb7dcf476c1'
+`
 ````
 
 

--- a/api/api.go
+++ b/api/api.go
@@ -20,7 +20,7 @@ type RemoteCalls interface {
 	GetCustomerByID(ctx context.Context, request model.GetCustomerByIDRequest) (model.CustomerInfo, error)
 	GetCustomerBalance(ctx context.Context, request model.GetCustomerBalanceRequest) (model.CustomerBalanceResponse, error)
 	GetCustomerBalances(ctx context.Context, customerID uuid.UUID) (model.CustomerBalancesResponse, error)
-	DeleteCustomer(ctx context.Context, customerId uuid.UUID) error
+	DeleteCustomer(ctx context.Context, customerID uuid.UUID) error
 
 	// Yield APIs
 	GetBusinessPortfolios(ctx context.Context) ([]model.Portfolio, error)

--- a/api/bank.go
+++ b/api/bank.go
@@ -26,9 +26,6 @@ func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResol
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.AccountDetailResponse `json:"data"`
 	}{}
@@ -37,7 +34,7 @@ func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResol
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -69,9 +66,6 @@ func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data []model.BankCodeResponse `json:"data"`
 	}{}
@@ -79,7 +73,7 @@ func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -112,10 +106,6 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.BankAccountResponse `json:"data"`
 	}{}
@@ -124,10 +114,7 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -159,16 +146,13 @@ func (c *Call) GetBankAccount(ctx context.Context, customerID uuid.UUID) (model.
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.BankAccountResponse `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/api/bank.go
+++ b/api/bank.go
@@ -106,6 +106,8 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.BankAccountResponse `json:"data"`
 	}{}
@@ -114,7 +116,10 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/bank.go
+++ b/api/bank.go
@@ -26,8 +26,8 @@ func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResol
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	// extract request id from context
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.AccountDetailResponse `json:"data"`
@@ -37,7 +37,7 @@ func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResol
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -70,7 +70,7 @@ func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data []model.BankCodeResponse `json:"data"`
@@ -79,7 +79,7 @@ func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -114,7 +114,7 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.BankAccountResponse `json:"data"`
@@ -126,7 +126,7 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -160,7 +160,7 @@ func (c *Call) GetBankAccount(ctx context.Context, customerID uuid.UUID) (model.
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.BankAccountResponse `json:"data"`
@@ -168,7 +168,7 @@ func (c *Call) GetBankAccount(ctx context.Context, customerID uuid.UUID) (model.
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/api/bank.go
+++ b/api/bank.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+
 	"github.com/ovalfi/go-sdk/helpers"
 	"github.com/ovalfi/go-sdk/model"
 )
@@ -25,6 +26,9 @@ func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResol
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.AccountDetailResponse `json:"data"`
 	}{}
@@ -33,6 +37,7 @@ func (c Call) ResolveBankAccount(ctx context.Context, request model.AccountResol
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -64,6 +69,9 @@ func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data []model.BankCodeResponse `json:"data"`
 	}{}
@@ -71,6 +79,7 @@ func (c Call) GetBanks(ctx context.Context) ([]model.BankCodeResponse, error) {
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -104,6 +113,9 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.BankAccountResponse `json:"data"`
 	}{}
@@ -112,7 +124,10 @@ func (c *Call) GenerateBankAccount(ctx context.Context, request model.BankAccoun
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -144,12 +159,16 @@ func (c *Call) GetBankAccount(ctx context.Context, customerID uuid.UUID) (model.
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.BankAccountResponse `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/api/customer.go
+++ b/api/customer.go
@@ -23,6 +23,9 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Customer `json:"data"`
 	}{}
@@ -30,7 +33,10 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -63,6 +69,9 @@ func (c *Call) UpdateCustomer(ctx context.Context, request model.UpdateCustomerR
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Customer `json:"data"`
 	}{}
@@ -70,6 +79,7 @@ func (c *Call) UpdateCustomer(ctx context.Context, request model.UpdateCustomerR
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Patch(endpoint)
 
@@ -102,12 +112,16 @@ func (c *Call) GetAllCustomers(ctx context.Context) ([]model.Customer, error) {
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data []model.Customer `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -140,12 +154,16 @@ func (c *Call) GetCustomerByID(ctx context.Context, request model.GetCustomerByI
 	fL.Info().Str("customerID", request.CustomerID).Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.CustomerInfo `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -178,6 +196,9 @@ func (c Call) GetCustomerBalance(ctx context.Context, request model.GetCustomerB
 	fL.Info().Str("customerID", request.CustomerID.String()).Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.CustomerBalanceResponse `json:"data"`
 	}{}
@@ -185,6 +206,7 @@ func (c Call) GetCustomerBalance(ctx context.Context, request model.GetCustomerB
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -217,12 +239,16 @@ func (c Call) GetCustomerBalances(ctx context.Context, customerID uuid.UUID) (mo
 	fL.Info().Str("customerID", customerID.String()).Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.CustomerBalancesResponse `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -246,6 +272,7 @@ func (c Call) GetCustomerBalances(ctx context.Context, customerID uuid.UUID) (mo
 	return response.Data, nil
 }
 
+// DeleteCustomer to delete a customer record by customer id
 func (c Call) DeleteCustomer(ctx context.Context, customerID uuid.UUID) error {
 	endpoint := fmt.Sprintf("%s%s/%s", c.baseURL, customerAPIVersion, customerID)
 
@@ -255,11 +282,15 @@ func (c Call) DeleteCustomer(ctx context.Context, customerID uuid.UUID) error {
 
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	var response interface{}
 
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Delete(endpoint)
 

--- a/api/customer.go
+++ b/api/customer.go
@@ -24,7 +24,7 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Customer `json:"data"`
@@ -35,7 +35,7 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -70,7 +70,7 @@ func (c *Call) UpdateCustomer(ctx context.Context, request model.UpdateCustomerR
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Customer `json:"data"`
@@ -79,7 +79,7 @@ func (c *Call) UpdateCustomer(ctx context.Context, request model.UpdateCustomerR
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Patch(endpoint)
 
@@ -113,7 +113,7 @@ func (c *Call) GetAllCustomers(ctx context.Context) ([]model.Customer, error) {
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data []model.Customer `json:"data"`
@@ -121,7 +121,7 @@ func (c *Call) GetAllCustomers(ctx context.Context) ([]model.Customer, error) {
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -155,7 +155,7 @@ func (c *Call) GetCustomerByID(ctx context.Context, request model.GetCustomerByI
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.CustomerInfo `json:"data"`
@@ -163,7 +163,7 @@ func (c *Call) GetCustomerByID(ctx context.Context, request model.GetCustomerByI
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -197,7 +197,7 @@ func (c Call) GetCustomerBalance(ctx context.Context, request model.GetCustomerB
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.CustomerBalanceResponse `json:"data"`
@@ -206,7 +206,7 @@ func (c Call) GetCustomerBalance(ctx context.Context, request model.GetCustomerB
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -240,7 +240,7 @@ func (c Call) GetCustomerBalances(ctx context.Context, customerID uuid.UUID) (mo
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.CustomerBalancesResponse `json:"data"`
@@ -248,7 +248,7 @@ func (c Call) GetCustomerBalances(ctx context.Context, customerID uuid.UUID) (mo
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -283,14 +283,14 @@ func (c Call) DeleteCustomer(ctx context.Context, customerID uuid.UUID) error {
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	var response interface{}
 
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Delete(endpoint)
 

--- a/api/customer.go
+++ b/api/customer.go
@@ -22,10 +22,6 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Customer `json:"data"`
 	}{}
@@ -33,10 +29,7 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -69,9 +62,6 @@ func (c *Call) UpdateCustomer(ctx context.Context, request model.UpdateCustomerR
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Customer `json:"data"`
 	}{}
@@ -79,7 +69,7 @@ func (c *Call) UpdateCustomer(ctx context.Context, request model.UpdateCustomerR
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Patch(endpoint)
 
@@ -112,16 +102,13 @@ func (c *Call) GetAllCustomers(ctx context.Context) ([]model.Customer, error) {
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data []model.Customer `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -154,16 +141,13 @@ func (c *Call) GetCustomerByID(ctx context.Context, request model.GetCustomerByI
 	fL.Info().Str("customerID", request.CustomerID).Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.CustomerInfo `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -196,9 +180,6 @@ func (c Call) GetCustomerBalance(ctx context.Context, request model.GetCustomerB
 	fL.Info().Str("customerID", request.CustomerID.String()).Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.CustomerBalanceResponse `json:"data"`
 	}{}
@@ -206,7 +187,7 @@ func (c Call) GetCustomerBalance(ctx context.Context, request model.GetCustomerB
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -239,16 +220,13 @@ func (c Call) GetCustomerBalances(ctx context.Context, customerID uuid.UUID) (mo
 	fL.Info().Str("customerID", customerID.String()).Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.CustomerBalancesResponse `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -282,15 +260,12 @@ func (c Call) DeleteCustomer(ctx context.Context, customerID uuid.UUID) error {
 
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	var response interface{}
 
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Delete(endpoint)
 

--- a/api/customer.go
+++ b/api/customer.go
@@ -22,6 +22,8 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.Customer `json:"data"`
 	}{}
@@ -29,7 +31,10 @@ func (c *Call) CreateCustomer(ctx context.Context, request model.CreateCustomerR
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/deposit.go
+++ b/api/deposit.go
@@ -27,6 +27,8 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.Deposit `json:"data"`
 	}{}
@@ -35,7 +37,10 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -146,6 +151,8 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.Deposit `json:"data"`
 	}{}
@@ -154,7 +161,10 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -187,6 +197,8 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.IntraTransferResponse `json:"data"`
 	}{}
@@ -195,7 +207,10 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/deposit.go
+++ b/api/deposit.go
@@ -27,10 +27,6 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Deposit `json:"data"`
 	}{}
@@ -39,10 +35,7 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -75,16 +68,13 @@ func (c *Call) GetAllDeposits(ctx context.Context) (model.DepositBatchResponse, 
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.DepositBatchResponse `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -117,16 +107,13 @@ func (c *Call) GetDepositID(ctx context.Context, id uuid.UUID) (model.Deposit, e
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Deposit `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -159,10 +146,6 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Deposit `json:"data"`
 	}{}
@@ -171,10 +154,7 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -207,10 +187,6 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.IntraTransferResponse `json:"data"`
 	}{}
@@ -219,10 +195,7 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/deposit.go
+++ b/api/deposit.go
@@ -29,7 +29,7 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Deposit `json:"data"`
@@ -41,7 +41,7 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -76,7 +76,7 @@ func (c *Call) GetAllDeposits(ctx context.Context) (model.DepositBatchResponse, 
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.DepositBatchResponse `json:"data"`
@@ -84,7 +84,7 @@ func (c *Call) GetAllDeposits(ctx context.Context) (model.DepositBatchResponse, 
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -118,7 +118,7 @@ func (c *Call) GetDepositID(ctx context.Context, id uuid.UUID) (model.Deposit, e
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Deposit `json:"data"`
@@ -126,7 +126,7 @@ func (c *Call) GetDepositID(ctx context.Context, id uuid.UUID) (model.Deposit, e
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -161,7 +161,7 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Deposit `json:"data"`
@@ -173,7 +173,7 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -209,7 +209,7 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.IntraTransferResponse `json:"data"`
@@ -221,7 +221,7 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)

--- a/api/deposit.go
+++ b/api/deposit.go
@@ -28,6 +28,9 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Deposit `json:"data"`
 	}{}
@@ -36,7 +39,10 @@ func (c *Call) InitiateDeposit(ctx context.Context, request model.InitiateDeposi
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -69,12 +75,16 @@ func (c *Call) GetAllDeposits(ctx context.Context) (model.DepositBatchResponse, 
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.DepositBatchResponse `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -107,12 +117,16 @@ func (c *Call) GetDepositID(ctx context.Context, id uuid.UUID) (model.Deposit, e
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Deposit `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -146,6 +160,9 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Deposit `json:"data"`
 	}{}
@@ -154,7 +171,10 @@ func (c *Call) InternalFundsTransfer(ctx context.Context, request model.FundTran
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -188,6 +208,9 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.IntraTransferResponse `json:"data"`
 	}{}
@@ -196,7 +219,10 @@ func (c *Call) IntraTransfer(ctx context.Context, request model.IntraTransferReq
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/transaction.go
+++ b/api/transaction.go
@@ -56,9 +56,6 @@ func (c *Call) GetTransactions(ctx context.Context, request *model.TransactionRe
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.TransactionResponse `json:"data"`
 	}{}
@@ -66,7 +63,7 @@ func (c *Call) GetTransactions(ctx context.Context, request *model.TransactionRe
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetResult(&response).
 		SetContext(ctx).
 		Get(endpoint)

--- a/api/transaction.go
+++ b/api/transaction.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/ovalfi/go-sdk/helpers"
 	"github.com/ovalfi/go-sdk/model"
 )
 
@@ -55,6 +56,9 @@ func (c *Call) GetTransactions(ctx context.Context, request *model.TransactionRe
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.TransactionResponse `json:"data"`
 	}{}
@@ -62,6 +66,7 @@ func (c *Call) GetTransactions(ctx context.Context, request *model.TransactionRe
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetResult(&response).
 		SetContext(ctx).
 		Get(endpoint)

--- a/api/transaction.go
+++ b/api/transaction.go
@@ -57,7 +57,7 @@ func (c *Call) GetTransactions(ctx context.Context, request *model.TransactionRe
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.TransactionResponse `json:"data"`
@@ -66,7 +66,7 @@ func (c *Call) GetTransactions(ctx context.Context, request *model.TransactionRe
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetResult(&response).
 		SetContext(ctx).
 		Get(endpoint)

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -23,7 +23,7 @@ func (c *Call) InitiateTransfer(ctx context.Context, request model.InitiateTrans
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Transfer `json:"data"`
@@ -35,7 +35,7 @@ func (c *Call) InitiateTransfer(ctx context.Context, request model.InitiateTrans
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -72,7 +72,7 @@ func (c *Call) GetExchangeRates(ctx context.Context, request model.GetExchangeRa
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.ExchangeRateDetails `json:"data"`
@@ -80,7 +80,7 @@ func (c *Call) GetExchangeRates(ctx context.Context, request model.GetExchangeRa
 
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetBody(request).
 		SetResult(&response).
 		SetContext(ctx).

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -21,10 +21,6 @@ func (c *Call) InitiateTransfer(ctx context.Context, request model.InitiateTrans
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Transfer `json:"data"`
 	}{}
@@ -33,10 +29,7 @@ func (c *Call) InitiateTransfer(ctx context.Context, request model.InitiateTrans
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -71,16 +64,13 @@ func (c *Call) GetExchangeRates(ctx context.Context, request model.GetExchangeRa
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.ExchangeRateDetails `json:"data"`
 	}{}
 
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetBody(request).
 		SetResult(&response).
 		SetContext(ctx).

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -21,6 +21,8 @@ func (c *Call) InitiateTransfer(ctx context.Context, request model.InitiateTrans
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.Transfer `json:"data"`
 	}{}
@@ -29,7 +31,10 @@ func (c *Call) InitiateTransfer(ctx context.Context, request model.InitiateTrans
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -24,7 +24,7 @@ func (c Call) GetWallet(ctx context.Context, request model.WalletRequest) (model
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Wallet `json:"data"`
@@ -32,7 +32,7 @@ func (c Call) GetWallet(ctx context.Context, request model.WalletRequest) (model
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -66,7 +66,7 @@ func (c Call) GetWallets(ctx context.Context, customerID string) ([]*model.Walle
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data []*model.Wallet `json:"data"`
@@ -74,7 +74,7 @@ func (c Call) GetWallets(ctx context.Context, customerID string) ([]*model.Walle
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -107,7 +107,7 @@ func (c Call) GetSupportedAssets(ctx context.Context) ([]*model.SupportedAsset, 
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data []*model.SupportedAsset `json:"data"`
@@ -115,7 +115,7 @@ func (c Call) GetSupportedAssets(ctx context.Context) ([]*model.SupportedAsset, 
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/ovalfi/go-sdk/helpers"
 	"github.com/ovalfi/go-sdk/model"
 )
 
@@ -22,12 +23,16 @@ func (c Call) GetWallet(ctx context.Context, request model.WalletRequest) (model
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Wallet `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -60,12 +65,16 @@ func (c Call) GetWallets(ctx context.Context, customerID string) ([]*model.Walle
 	fL.Info().Interface(model.LogStrRequest, customerID).Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data []*model.Wallet `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -97,12 +106,16 @@ func (c Call) GetSupportedAssets(ctx context.Context) ([]*model.SupportedAsset, 
 	fL.Info().Msg("starting...")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data []*model.SupportedAsset `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -23,16 +23,13 @@ func (c Call) GetWallet(ctx context.Context, request model.WalletRequest) (model
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Wallet `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -65,16 +62,13 @@ func (c Call) GetWallets(ctx context.Context, customerID string) ([]*model.Walle
 	fL.Info().Interface(model.LogStrRequest, customerID).Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data []*model.Wallet `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -106,16 +100,13 @@ func (c Call) GetSupportedAssets(ctx context.Context) ([]*model.SupportedAsset, 
 	fL.Info().Msg("starting...")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data []*model.SupportedAsset `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/api/withdrawal.go
+++ b/api/withdrawal.go
@@ -22,7 +22,7 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Withdrawal `json:"data"`
@@ -34,7 +34,7 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -71,7 +71,7 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Withdrawal `json:"data"`
@@ -83,7 +83,7 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -119,7 +119,7 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.Withdrawal `json:"data"`
@@ -131,7 +131,7 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -167,7 +167,7 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.FeeWithdrawal `json:"data"`
@@ -179,7 +179,7 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)

--- a/api/withdrawal.go
+++ b/api/withdrawal.go
@@ -20,10 +20,6 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -32,10 +28,7 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -69,10 +62,6 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -81,10 +70,7 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -117,10 +103,6 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -129,10 +111,7 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -165,10 +144,6 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.FeeWithdrawal `json:"data"`
 	}{}
@@ -177,10 +152,7 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/withdrawal.go
+++ b/api/withdrawal.go
@@ -20,6 +20,8 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 	fL.Info().Interface(model.LogStrRequest, request).Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -28,7 +30,10 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -62,6 +67,8 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -70,7 +77,10 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -103,6 +113,8 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -111,7 +123,10 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -144,6 +159,8 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.FeeWithdrawal `json:"data"`
 	}{}
@@ -152,7 +169,10 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/withdrawal.go
+++ b/api/withdrawal.go
@@ -21,6 +21,9 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -29,7 +32,10 @@ func (c *Call) InitiateWithdrawal(ctx context.Context, request model.InitiateWit
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -64,6 +70,9 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -72,7 +81,10 @@ func (c *Call) FiatWithdrawal(ctx context.Context, request model.WithdrawalReque
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -106,6 +118,9 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.Withdrawal `json:"data"`
 	}{}
@@ -114,7 +129,10 @@ func (c Call) CryptoWithdrawal(ctx context.Context, request model.WithdrawalRequ
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -148,6 +166,9 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.FeeWithdrawal `json:"data"`
 	}{}
@@ -156,7 +177,10 @@ func (c *Call) FeeWithdrawal(ctx context.Context, request model.FeeWithdrawalReq
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/yield.go
+++ b/api/yield.go
@@ -20,7 +20,7 @@ func (c *Call) GetBusinessPortfolios(ctx context.Context) ([]model.Portfolio, er
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data []model.Portfolio `json:"data"`
@@ -28,7 +28,7 @@ func (c *Call) GetBusinessPortfolios(ctx context.Context) ([]model.Portfolio, er
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -64,7 +64,7 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.YieldOfferingProfile `json:"data"`
@@ -75,7 +75,7 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 		SetResult(&response).
 		SetHeaders(map[string]string{
 			"Signature":              signature,
-			model.RequestIDHeaderKey: ctxValue,
+			model.RequestIDHeaderKey: requestID,
 		}).
 		SetContext(ctx).
 		Post(endpoint)
@@ -110,7 +110,7 @@ func (c *Call) UpdateYieldOfferingProfile(ctx context.Context, request model.Upd
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.UpdatedYieldOfferingProfile `json:"data"`
@@ -119,7 +119,7 @@ func (c *Call) UpdateYieldOfferingProfile(ctx context.Context, request model.Upd
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Put(endpoint)
 
@@ -153,7 +153,7 @@ func (c *Call) GetAllYieldProfiles(ctx context.Context) ([]model.YieldOfferingPr
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data []model.YieldOfferingProfile `json:"data"`
@@ -161,7 +161,7 @@ func (c *Call) GetAllYieldProfiles(ctx context.Context) ([]model.YieldOfferingPr
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -195,7 +195,7 @@ func (c *Call) GetYieldProfileByID(ctx context.Context, request model.GetYieldPr
 	defer fL.Info().Msg("done...")
 
 	// extract request id value from context
-	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+	requestID := helpers.GetRequestID(ctx)
 
 	response := struct {
 		Data model.YieldOfferingProfile `json:"data"`
@@ -203,7 +203,7 @@ func (c *Call) GetYieldProfileByID(ctx context.Context, request model.GetYieldPr
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, ctxValue).
+		SetHeader(model.RequestIDHeaderKey, requestID).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/api/yield.go
+++ b/api/yield.go
@@ -19,12 +19,16 @@ func (c *Call) GetBusinessPortfolios(ctx context.Context) ([]model.Portfolio, er
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data []model.Portfolio `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -59,6 +63,9 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 	defer fL.Info().Msg("done...")
 
 	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.YieldOfferingProfile `json:"data"`
 	}{}
@@ -66,7 +73,10 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader("Signature", signature).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: ctxValue,
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -99,6 +109,9 @@ func (c *Call) UpdateYieldOfferingProfile(ctx context.Context, request model.Upd
 	fL.Info().Str("name", request.Name).Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.UpdatedYieldOfferingProfile `json:"data"`
 	}{}
@@ -106,6 +119,7 @@ func (c *Call) UpdateYieldOfferingProfile(ctx context.Context, request model.Upd
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Put(endpoint)
 
@@ -138,12 +152,16 @@ func (c *Call) GetAllYieldProfiles(ctx context.Context) ([]model.YieldOfferingPr
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data []model.YieldOfferingProfile `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -176,12 +194,16 @@ func (c *Call) GetYieldProfileByID(ctx context.Context, request model.GetYieldPr
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	// extract request id value from context
+	ctxValue, _ := helpers.GetContextValue(ctx, model.RequestIDContextKey)
+
 	response := struct {
 		Data model.YieldOfferingProfile `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
+		SetHeader(model.RequestIDHeaderKey, ctxValue).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/api/yield.go
+++ b/api/yield.go
@@ -59,6 +59,8 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
+	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
+
 	response := struct {
 		Data model.YieldOfferingProfile `json:"data"`
 	}{}
@@ -66,7 +68,10 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
+		SetHeaders(map[string]string{
+			"Signature":              signature,
+			model.RequestIDHeaderKey: helpers.GetRequestID(ctx),
+		}).
 		SetContext(ctx).
 		Post(endpoint)
 

--- a/api/yield.go
+++ b/api/yield.go
@@ -19,16 +19,13 @@ func (c *Call) GetBusinessPortfolios(ctx context.Context) ([]model.Portfolio, er
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data []model.Portfolio `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -62,10 +59,6 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 		Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	signature := helpers.GetSignatureFromReferenceAndPubKey(request.Reference, c.publicKey)
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.YieldOfferingProfile `json:"data"`
 	}{}
@@ -73,10 +66,7 @@ func (c *Call) CreateYieldOfferingProfile(ctx context.Context, request model.Cre
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeaders(map[string]string{
-			"Signature":              signature,
-			model.RequestIDHeaderKey: requestID,
-		}).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Post(endpoint)
 
@@ -109,9 +99,6 @@ func (c *Call) UpdateYieldOfferingProfile(ctx context.Context, request model.Upd
 	fL.Info().Str("name", request.Name).Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.UpdatedYieldOfferingProfile `json:"data"`
 	}{}
@@ -119,7 +106,7 @@ func (c *Call) UpdateYieldOfferingProfile(ctx context.Context, request model.Upd
 		SetAuthToken(c.bearerToken).
 		SetBody(request).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Put(endpoint)
 
@@ -152,16 +139,13 @@ func (c *Call) GetAllYieldProfiles(ctx context.Context) ([]model.YieldOfferingPr
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data []model.YieldOfferingProfile `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 
@@ -194,16 +178,13 @@ func (c *Call) GetYieldProfileByID(ctx context.Context, request model.GetYieldPr
 	fL.Info().Interface(model.LogStrRequest, "empty").Msg("request")
 	defer fL.Info().Msg("done...")
 
-	// extract request id value from context
-	requestID := helpers.GetRequestID(ctx)
-
 	response := struct {
 		Data model.YieldOfferingProfile `json:"data"`
 	}{}
 	res, err := c.client.R().
 		SetAuthToken(c.bearerToken).
 		SetResult(&response).
-		SetHeader(model.RequestIDHeaderKey, requestID).
+		SetHeader(model.RequestIDHeaderKey, helpers.GetRequestID(ctx)).
 		SetContext(ctx).
 		Get(endpoint)
 

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -2,8 +2,12 @@
 package helpers
 
 import (
+	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
+
+	"github.com/ovalfi/go-sdk/model"
 )
 
 // GetSignatureFromReferenceAndPubKey returns the string equivalent of a SHA256 hash on reference and public key
@@ -12,4 +16,13 @@ func GetSignatureFromReferenceAndPubKey(reference, publicKey string) string {
 	hash := sha256.New()
 	hash.Write([]byte(concat))
 	return fmt.Sprintf("%x", hash.Sum(nil))
+}
+
+// GetContextValue to extract the request-id value from the context passed
+func GetContextValue(ctx context.Context, k model.Key) (string, error) {
+	if v := ctx.Value(k); v != nil {
+		fmt.Println("found value:", v)
+		return fmt.Sprintf("%s", v), nil
+	}
+	return "", errors.New("something-went-wrong")
 }

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -4,7 +4,6 @@ package helpers
 import (
 	"context"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 
 	"github.com/ovalfi/go-sdk/model"
@@ -18,11 +17,11 @@ func GetSignatureFromReferenceAndPubKey(reference, publicKey string) string {
 	return fmt.Sprintf("%x", hash.Sum(nil))
 }
 
-// GetContextValue to extract the request-id value from the context passed
-func GetContextValue(ctx context.Context, k model.Key) (string, error) {
-	if v := ctx.Value(k); v != nil {
-		fmt.Println("found value:", v)
-		return fmt.Sprintf("%s", v), nil
+// GetRequestID to extract request-id from context
+func GetRequestID(ctx context.Context) string {
+	if rID := ctx.Value(model.RequestIDContextKey); rID != nil {
+		return rID.(string)
 	}
-	return "", errors.New("something-went-wrong")
+
+	return ""
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/ovalfi/go-sdk/model/example"
 	"github.com/rs/zerolog"
 
 	"github.com/ovalfi/go-sdk/api"
@@ -34,12 +37,12 @@ func main() {
 	}
 	fmt.Printf("new customer: %+v\n", updatedCustomer)*/
 
-	/*retrievedCustomer, err := apiCalls.GetCustomerByID(ctx, example.NewGetCustomerByIDRequest)
+	retrievedCustomer, err := apiCalls.GetCustomerByID(context.Background(), example.NewGetCustomerByIDRequest)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	fmt.Printf("new customer: %+v\n", retrievedCustomer)*/
+	fmt.Printf("new customer: %+v\n", retrievedCustomer)
 
 	/*retrievedCustomers, err := apiCalls.GetAllCustomers(ctx)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"os"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/ovalfi/go-sdk/model/example"
 	"github.com/rs/zerolog"
 
 	"github.com/ovalfi/go-sdk/api"
@@ -37,12 +34,12 @@ func main() {
 	}
 	fmt.Printf("new customer: %+v\n", updatedCustomer)*/
 
-	retrievedCustomer, err := apiCalls.GetCustomerByID(context.Background(), example.NewGetCustomerByIDRequest)
+	/*retrievedCustomer, err := apiCalls.GetCustomerByID(context.Background(), example.NewGetCustomerByIDRequest)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	fmt.Printf("new customer: %+v\n", retrievedCustomer)
+	fmt.Printf("new customer: %+v\n", retrievedCustomer)*/
 
 	/*retrievedCustomers, err := apiCalls.GetAllCustomers(ctx)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"os"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/ovalfi/go-sdk/model/example"
 	"github.com/rs/zerolog"
 
 	"github.com/ovalfi/go-sdk/api"
@@ -82,12 +79,12 @@ func main() {
 	}
 	fmt.Printf("yield profiles: %+v\n", yieldProfiles)*/
 
-	retrievedYieldProfile, err := apiCalls.GetYieldProfileByID(context.Background(), example.NewGetYieldProfileByIDRequest)
+	/*retrievedYieldProfile, err := apiCalls.GetYieldProfileByID(context.Background(), example.NewGetYieldProfileByIDRequest)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	fmt.Printf("retrieved yield profile: %+v\n", retrievedYieldProfile)
+	fmt.Printf("retrieved yield profile: %+v\n", retrievedYieldProfile)*/
 
 	//newDeposit, err := apiCalls.InitiateDeposit(ctx, example.NewDepositRequest)
 	//if err != nil {

--- a/model/example/example.go
+++ b/model/example/example.go
@@ -59,12 +59,14 @@ var (
 		YieldProfileID: "ef8891af-e887-4e2c-ac79-7a9682d1ad77",
 	}
 
+	// NewDepositRequest newDepositRequest model
 	NewDepositRequest = model.InitiateDepositRequest{
 		CustomerID: "cefec56e-3781-4b3a-bda6-ba4e7c0e49cd",
 		Reference:  "ref123",
 		Amount:     300,
 	}
 
+	// NewTransferRequest newTransferRequest model
 	NewTransferRequest = model.InitiateTransferRequest{
 		CustomerID: "cefec56e-3781-4b3a-bda6-ba4e7c0e49cd",
 		Amount:     20,
@@ -98,6 +100,7 @@ var (
 		Reference: "ref123",
 	}
 
+	//NewInitiateWithdrawalRequest newInitiateWithdrawalRequest model
 	NewInitiateWithdrawalRequest = model.InitiateWithdrawalRequest{
 		CustomerID: "cefec56e-3781-4b3a-bda6-ba4e7c0e49cd",
 		Reference:  "ref123",

--- a/model/model.go
+++ b/model/model.go
@@ -8,6 +8,11 @@ import (
 	"github.com/google/uuid"
 )
 
+type (
+	// Key is a middleware key sting value
+	Key string
+)
+
 const (
 	// BaseURL is the definition of ovalfi base url
 	BaseURL = "https://sandbox-api.ovalfi-app.com/api/"
@@ -41,9 +46,13 @@ const (
 
 	// FeeTypeAmount represent FeeType in amount
 	FeeTypeAmount FeeType = "amount"
+
+	// RequestIDContextKey contact that holds the RequestID context key for app to storage later pass through
+	RequestIDContextKey Key = "penta_RequestIDContextKey"
+	// RequestIDHeaderKey a constant for the request id header key
+	RequestIDHeaderKey string = "X-REQUEST-ID"
 )
 
-// Requests for the endpoints
 type (
 	// CreateCustomerRequest attributes payload to create new API customer
 	CreateCustomerRequest struct {
@@ -167,6 +176,7 @@ type (
 		Asset      string `json:"asset"`
 	}
 
+	// FundTransferAction string
 	FundTransferAction string
 
 	// FundTransferRequest attributes payload to transfer funds from one yield offering to another
@@ -237,6 +247,7 @@ type (
 		YieldOfferingID     uuid.UUID `json:"yield_offering_id" validate:"required"`
 	}
 
+	// FeeType feeType string
 	FeeType string
 )
 

--- a/model/model.go
+++ b/model/model.go
@@ -47,8 +47,8 @@ const (
 	// FeeTypeAmount represent FeeType in amount
 	FeeTypeAmount FeeType = "amount"
 
-	// RequestIDContextKey contact that holds the RequestID context key for app to storage later pass through
-	RequestIDContextKey Key = "penta_RequestIDContextKey"
+	// RequestIDContextKey contact that holds the RequestID context key for
+	RequestIDContextKey Key = "api_RequestIDContextKey"
 	// RequestIDHeaderKey a constant for the request id header key
 	RequestIDHeaderKey string = "X-REQUEST-ID"
 )


### PR DESCRIPTION
- We want to synchronize the requestIDs passed from, consumer-app for example, via oval sdk, to oval core backend infrastructure.
- So, we cater for for the above by setting the request-id value on the header, for calls to externalapi.