### PR TITLE
Add Delete Card endpoint to go-sdk

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -106,6 +106,7 @@ type RemoteCalls interface {
 	GetCustomerCardByID(ctx context.Context, cardID string) (model.Card, error)
 	FundCustomerCard(ctx context.Context, request model.FundCustomerCardRequest) (model.Card, error)
 	GetCustomerCardSecureDetails(ctx context.Context, cardID, customerID string) (model.VaultedCardDetails, error)
+	DeleteCard(ctx context.Context, cardID, customerID string) (string, error)
 
 	// RunInSandboxMode this forces Call functionalities to run in sandbox mode for relevant logic/API consumption
 	RunInSandboxMode()

--- a/api/card.go
+++ b/api/card.go
@@ -85,3 +85,15 @@ func (c *Call) GetCustomerCardSecureDetails(ctx context.Context, cardID, custome
 	err = c.makeRequest(ctx, path, http.MethodGet, nil, nil, nil, nil, &response)
 	return response, err
 }
+
+// DeleteCard makes request to Torus to delete/terminate a customer card
+func (c *Call) DeleteCard(ctx context.Context, cardID, customerID string) (string, error) {
+	var (
+		err      error
+		response string
+		path     = fmt.Sprintf("v1/cards/%s?customer_id=%s", cardID, customerID)
+	)
+
+	err = c.makeRequest(ctx, path, http.MethodDelete, nil, nil, nil, nil, &response)
+	return response, err
+}

--- a/api/mock/mock_api.go
+++ b/api/mock/mock_api.go
@@ -167,6 +167,21 @@ func (mr *MockRemoteCallsMockRecorder) DebitPaymentCard(ctx, request interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DebitPaymentCard", reflect.TypeOf((*MockRemoteCalls)(nil).DebitPaymentCard), ctx, request)
 }
 
+// DeleteCard mocks base method.
+func (m *MockRemoteCalls) DeleteCard(ctx context.Context, cardID, customerID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCard", ctx, cardID, customerID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteCard indicates an expected call of DeleteCard.
+func (mr *MockRemoteCallsMockRecorder) DeleteCard(ctx, cardID, customerID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCard", reflect.TypeOf((*MockRemoteCalls)(nil).DeleteCard), ctx, cardID, customerID)
+}
+
 // DeleteCustomer mocks base method.
 func (m *MockRemoteCalls) DeleteCustomer(ctx context.Context, customerID string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- added the endpoint to delete or terminate a card
`DELETE /cards/:id`